### PR TITLE
BUGFIX: prevent failure for disabled superTypes

### DIFF
--- a/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
+++ b/Classes/Aspects/NodeTypeConfigurationEnrichmentAspect.php
@@ -101,7 +101,10 @@ class NodeTypeConfigurationEnrichmentAspect
             }
 
             $editorName = $propertyConfiguration['ui']['inspector']['editor']
-                ?? array_reduce($declaredSuperTypes, function ($editorName, NodeType $superType) use ($propertyName) {
+                ?? array_reduce($declaredSuperTypes, function ($editorName, ?NodeType $superType) use ($propertyName) {
+                    if ($superType === null) {
+                        return $editorName;
+                    }
                     $superTypeConfiguration = $superType->getLocalConfiguration();
                     return $editorName ?? $superTypeConfiguration['properties'][$propertyName]['ui']['inspector']['editor'] ?? null;
                 }, null);


### PR DESCRIPTION
When there are disabled `superTypes` in NodeTypes, an exception is thrown.
This happens when a superType is disabled in a NodeType and no specific editor is defined.

```yaml
'My.Package:FormElement':
  superTypes:
    'Neos.Form.Builder:FormElement': true
    'Neos.Form.Builder:LabelMixin': false
    'Neos.Form.Builder:RequiredCheckboxMixin': false
  properties:
    property:
      type: string
      ui:
        label: i18n
```